### PR TITLE
Moved battery optimization checks to main activity and added dialog

### DIFF
--- a/app/app/src/main/java/com/octo4a/ui/InitialActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/InitialActivity.kt
@@ -1,9 +1,11 @@
 package com.octo4a.ui
 
 import android.Manifest
+import android.app.UiModeManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -29,9 +31,7 @@ import org.koin.android.ext.android.inject
 class InitialActivity: AppCompatActivity() {
     private val bootstrapRepository: BootstrapRepository by inject()
     private val prefs: MainPreferences by inject()
-    private val pm  by lazy { getSystemService(LifecycleService.POWER_SERVICE) as PowerManager }
     private val cameraEnumerationRepository: CameraEnumerationRepository by inject()
-    private val logger: LoggerRepository by inject()
 
     // Storage permission request
     private val hasStoragePermission: Boolean
@@ -56,22 +56,7 @@ class InitialActivity: AppCompatActivity() {
 
         cameraEnumerationRepository.enumerateCameras()
         installButton.setOnClickListener {
-            // Required for acquiring wakelock
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !pm.isIgnoringBatteryOptimizations(packageName)) {
-                val whitelist = Intent()
-                whitelist.action = Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-                whitelist.data = Uri.parse("package:$packageName")
-                whitelist.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                try {
-                    startActivity(whitelist)
-                } catch (e: ActivityNotFoundException) {
-                    checkWritePermissionAndRun()
-                    logger.log(this) { "failed to open battery optimization dialog" }
-                    Toast.makeText(this, "Failed to open battery optimization settings", Toast.LENGTH_LONG).show()
-                }
-            } else {
-                checkWritePermissionAndRun()
-            }
+            checkWritePermissionAndRun()
         }
     }
 

--- a/app/app/src/main/java/com/octo4a/ui/MainActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/MainActivity.kt
@@ -1,21 +1,37 @@
 package com.octo4a.ui
 
+import android.app.AlertDialog
+import android.app.UiModeManager
+import android.content.ActivityNotFoundException
+import android.content.DialogInterface
 import android.content.Intent
+import android.content.res.Configuration
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.PowerManager
+import android.provider.Settings
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.LifecycleService
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.octo4a.R
+import com.octo4a.repository.LoggerRepository
 import com.octo4a.serial.VirtualSerialDriver
 import com.octo4a.service.OctoPrintService
 import com.octo4a.ui.fragments.TerminalSheetDialog
+import com.octo4a.utils.preferences.MainPreferences
 import kotlinx.android.synthetic.main.activity_main.*
 import org.koin.android.ext.android.inject
 
 class MainActivity : AppCompatActivity() {
+    private val logger: LoggerRepository by inject()
     private val vsp: VirtualSerialDriver by inject()
+    private val mainPreferences: MainPreferences by inject()
+    private val pm  by lazy { getSystemService(LifecycleService.POWER_SERVICE) as PowerManager }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +39,48 @@ class MainActivity : AppCompatActivity() {
         setSupportActionBar(my_toolbar)
         bottomNavigationBar.setupWithNavController(findNavController(R.id.navHost))
         vsp.updateDevicesList(OctoPrintService.BROADCAST_SERVICE_USB_GOT_ACCESS)
+
+        // Required for acquiring wakelock
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !pm.isIgnoringBatteryOptimizations(packageName) && mainPreferences.warnDisableBatteryOptimization) {
+            showBatteryOptimizationDialog()
+        }
+    }
+
+    private fun showBatteryOptimizationDialog() {
+        val uiModeManager: UiModeManager = getSystemService(UI_MODE_SERVICE) as UiModeManager
+
+        val alertDialog: AlertDialog? = this.let {
+            val builder = AlertDialog.Builder(it)
+            builder.apply {
+                setTitle(R.string.disable_battery_optimization)
+                setMessage(R.string.disable_battery_optimization_msg)
+                setNegativeButton(R.string.action_never_ask_again) { dialog, id ->
+                    mainPreferences.warnDisableBatteryOptimization = false
+                }
+                setNeutralButton(R.string.action_later) { dialog, id ->
+                    // User cancelled the dialog
+                }
+
+                if (uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_NORMAL) {
+                    setPositiveButton(R.string.action_open_settings) { dialog, id ->
+                        val whitelist = Intent()
+                        whitelist.action = Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+                        whitelist.data = Uri.parse("package:$packageName")
+                        whitelist.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                        try {
+                            startActivity(whitelist)
+                        } catch (e: ActivityNotFoundException) {
+                            logger.log(this) { "failed to open battery optimization dialog" }
+                            Toast.makeText(this@MainActivity, "Failed to open battery optimization settings", Toast.LENGTH_LONG).show()
+                        }
+                    }
+                }
+            }
+
+            // Create the AlertDialog
+            builder.create()
+        }
+        alertDialog?.show()
     }
 
     // @TODO: refactor to non deprecated api

--- a/app/app/src/main/java/com/octo4a/utils/preferences/MainPreferences.kt
+++ b/app/app/src/main/java/com/octo4a/utils/preferences/MainPreferences.kt
@@ -11,4 +11,5 @@ class MainPreferences(context: Context) : Preferences(context, true) {
     var sshPort by stringPref(defaultValue = "8022")
     var flashWhenObserved by booleanPref()
     var updateDismissed by stringPref()
+    var warnDisableBatteryOptimization by booleanPref(defaultValue = true)
 }

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -37,6 +37,10 @@
     <string name="action_download">Download</string>
     <string name="action_later">Later</string>
     <string name="action_show_logs">Show logs</string>
+    <string name="action_never_ask_again">Never ask again</string>
+    <string name="action_open_settings">Open Settings</string>
+    <string name="disable_battery_optimization">Disable battery optimization</string>
+    <string name="disable_battery_optimization_msg">For stability reasons it is necessary to disable battery optimizations for this app in the system settings</string>
 
 
 </resources>


### PR DESCRIPTION
As an exercise learning Kotlin, I tried to improve on the existing behavior by doing the battery optimization checks in the main activity (as opposed to the initial activity), so if battery optimization is enabled the user will be presented with a dialog explaining that for stability reasons it is needed to be disabled.

Then he can choose to:
* Go to the system battery optimization settings (if we're running on a normal Android version, this doesn't work on Android TV and this button doesn't show)
* Be reminded next time
* Dismiss the warning permanently
