### PR TITLE
add fullscreen browser for the webinterface

### DIFF
--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -52,6 +52,8 @@
 
         <activity android:name=".ui.MainActivity">
         </activity>
+        <activity android:name=".ui.WebinterfaceActivity">
+        </activity>
         <activity android:name=".ui.InstallationActivity"/>
         <service android:name=".service.OctoPrintService">
 

--- a/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
@@ -1,0 +1,50 @@
+package com.octo4a.ui
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.View
+import android.view.WindowManager
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+import com.octo4a.R
+import kotlinx.android.synthetic.main.activity_webinterface.*
+
+class WebinterfaceActivity : AppCompatActivity() {
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_webinterface)
+        window.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+            WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        webview.visibility = View.GONE
+        webview.webViewClient = WebinterfaceClient(this, intent.data.authority)
+        webview.settings.loadsImagesAutomatically = true
+        webview.settings.javaScriptEnabled = true
+        webview.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
+        webview.loadUrl(intent.data.toString())
+    }
+
+    private fun webviewFinished() {
+        webview.visibility = View.VISIBLE
+        loadingIndicator.visibility = View.GONE
+    }
+
+    private class WebinterfaceClient(val activity: WebinterfaceActivity, val startAuthority: String): WebViewClient() {
+        override fun onPageFinished(view: WebView?, url: String?) {
+            activity.webviewFinished()
+            super.onPageFinished(view, url)
+        }
+
+        override fun shouldOverrideUrlLoading(
+            view: WebView?,
+            request: WebResourceRequest?
+        ): Boolean {
+            return request?.url?.authority != startAuthority
+        }
+    }
+
+
+}

--- a/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
@@ -56,10 +56,10 @@ class WebinterfaceActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        if (webview.canGoBack()) {
-            webview.goBack()
-        } else if (!isPinned()){
+        if (!isPinned()){
             super.onBackPressed()
+        } else if (webview.canGoBack()) {
+            webview.goBack()
         }
     }
 

--- a/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
@@ -89,6 +89,4 @@ class WebinterfaceActivity : AppCompatActivity() {
             }
         }
     }
-
-
 }

--- a/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
@@ -1,12 +1,14 @@
 package com.octo4a.ui
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.octo4a.R
 import kotlinx.android.synthetic.main.activity_webinterface.*
@@ -23,6 +25,8 @@ class WebinterfaceActivity : AppCompatActivity() {
         webview.webViewClient = WebinterfaceClient(this, intent.data.authority)
         webview.settings.loadsImagesAutomatically = true
         webview.settings.javaScriptEnabled = true
+        webview.settings.domStorageEnabled = true;
+        webview.settings.userAgentString = "TouchUI"
         webview.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
         webview.loadUrl(intent.data.toString())
     }
@@ -38,6 +42,7 @@ class WebinterfaceActivity : AppCompatActivity() {
             super.onPageFinished(view, url)
         }
 
+        @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
         override fun shouldOverrideUrlLoading(
             view: WebView?,
             request: WebResourceRequest?

--- a/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
+++ b/app/app/src/main/java/com/octo4a/ui/WebinterfaceActivity.kt
@@ -23,7 +23,6 @@ class WebinterfaceActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_webinterface)
-        webview.visibility = View.GONE
         webview.webViewClient = WebinterfaceClient(this)
         webview.settings.loadsImagesAutomatically = true
         webview.settings.javaScriptEnabled = true

--- a/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
+++ b/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
@@ -202,9 +202,7 @@ class ServerFragment : Fragment() {
     }
 
     private fun openWebInterface() {
-        val intent = Intent(context, WebinterfaceActivity::class.java)
-        intent.data = Uri.parse("http://127.0.0.1:5000/")
-        startActivity(intent)
+        startActivity(Intent(context, WebinterfaceActivity::class.java))
     }
 
     private fun showPreviewDialog() {

--- a/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
+++ b/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
@@ -195,7 +195,7 @@ class ServerFragment : Fragment() {
 
     private fun openWebInterface() {
         val intent = Intent(context, WebinterfaceActivity::class.java)
-        intent.data = Uri.parse("http://127.0.0.1:5000/#touch")
+        intent.data = Uri.parse("http://127.0.0.1:5000/")
         startActivity(intent)
     }
 

--- a/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
+++ b/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
@@ -116,6 +116,7 @@ class ServerFragment : Fragment() {
                 openWebInterface()
             }
         }
+
         statusViewModel.cameraStatus.observe(viewLifecycleOwner) {
             if (it) {
                 camServerStatus.title = getString(R.string.camserver_running)
@@ -168,6 +169,13 @@ class ServerFragment : Fragment() {
             }
             serverStatus.actionProgressbar.isGone = !it.progress
             serverStatus.actionButton.isGone = it.progress
+            if (it == ServerStatus.Running) {
+                serverStatus.setOnClickListener {
+                    openWebInterface()
+                }
+            } else {
+                serverStatus.setOnClickListener(null)
+            }
         }
 
         // Fetch autoupdater

--- a/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
+++ b/app/app/src/main/java/com/octo4a/ui/fragments/ServerFragment.kt
@@ -28,6 +28,7 @@ import com.octo4a.repository.LoggerRepository
 import com.octo4a.repository.ServerStatus
 import com.octo4a.serial.VirtualSerialDriver
 import com.octo4a.ui.InitialActivity
+import com.octo4a.ui.WebinterfaceActivity
 import com.octo4a.ui.views.UsbDeviceView
 import com.octo4a.utils.preferences.MainPreferences
 import com.octo4a.viewmodel.StatusViewModel
@@ -110,6 +111,11 @@ class ServerFragment : Fragment() {
             }
         }
 
+        serverStatus.setOnClickListener {
+            if (statusViewModel.serverStatus.value == ServerStatus.Running) {
+                openWebInterface()
+            }
+        }
         statusViewModel.cameraStatus.observe(viewLifecycleOwner) {
             if (it) {
                 camServerStatus.title = getString(R.string.camserver_running)
@@ -185,6 +191,12 @@ class ServerFragment : Fragment() {
                 }
                 .show()
         }
+    }
+
+    private fun openWebInterface() {
+        val intent = Intent(context, WebinterfaceActivity::class.java)
+        intent.data = Uri.parse("http://127.0.0.1:5000/#touch")
+        startActivity(intent)
     }
 
     private fun showPreviewDialog() {

--- a/app/app/src/main/res/layout/activity_webinterface.xml
+++ b/app/app/src/main/res/layout/activity_webinterface.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:fitsSystemWindows="true"
+        tools:context=".ui.MainActivity">
+
+    <ProgressBar
+        android:layout_gravity="center"
+        android:id="@+id/loadingIndicator"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <WebView
+        android:visibility="gone"
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </WebView>
+
+</FrameLayout>


### PR DESCRIPTION
This PR adds the following functionality:

* If octoprint is running and the user presses on the "OctoPrint is running" button, a fullscreen browser opens.
* If the touchUI extension is installed, it will be used
