### PR TITLE
Klipper Script: Add line break for nicer formatting

### DIFF
--- a/scripts/setup-klipper.sh
+++ b/scripts/setup-klipper.sh
@@ -11,7 +11,7 @@ then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
 fi
 
-echo -e "${COL}Installing dependencies...\n${NC}"
+echo -e "${COL}\nInstalling dependencies...\n${NC}"
 # install required dependencies
 apk add py3-cffi py3-greenlet linux-headers can-utils
 pip3 install python-can


### PR DESCRIPTION
Previously `Do you have "Plugin extras" installed? (y/n): yInstalling dependencies...` should now be
```
Do you have "Plugin extras" installed? (y/n): y
Installing dependencies...
```