### PR TITLE
Add dependencies for installing OctoPrint 1.8.3

### DIFF
--- a/scripts/setup-octo4a.sh
+++ b/scripts/setup-octo4a.sh
@@ -2,7 +2,7 @@
 
 set -e
 # install required dependencies
-apk add py3-pip py3-yaml py3-regex py3-netifaces py3-psutil unzip py3-pillow ttyd ffmpeg
+apk add py3-pip py3-yaml py3-regex py3-netifaces py3-psutil unzip py3-pillow ttyd ffmpeg libffi-dev gcc python3-dev musl-dev
 
 mkdir -p /root/extensions/ttyd
 cat << EOF > /root/extensions/ttyd/manifest.json


### PR DESCRIPTION
This is required for the newer password hashing libraries used in OctoPrint 1.8.3. We should have tested it on Octo4a as well, but as these fixes were only tested privately (due to it being a security update) it was unfortunately not done, so sorry about that.

@feelfreelinux, if a user updates the app, how can we make sure that these dependencies are installed? Or will it be done automatically by the app? That would allow them to update to 1.8.3.

I did have a strange issue when testing this via SSH as well, which was this error:
```
ERROR: Cannot uninstall 'packaging'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```
I am not completely sure what is requesting to update packaging, but it failed. Running `pip install -U packaging --ignore-installed` is a hacky way around it, but it did then allow me to complete the installation.